### PR TITLE
rust: add --rust-target-triple option

### DIFF
--- a/src/install_cmd.rs
+++ b/src/install_cmd.rs
@@ -34,6 +34,12 @@ pub struct InstallCmd {
     )]
     pub rust_debug_target: bool,
     #[clap(
+        long,
+        help = concat!("Use the generated binaries and libraries from this",
+                       " target triple (only effective for rust projects)")
+    )]
+    pub rust_target_triple: Option<String>,
+    #[clap(
         short = 'D',
         long,
         requires = "system",

--- a/src/install_cmd_impl.rs
+++ b/src/install_cmd_impl.rs
@@ -82,6 +82,7 @@ impl InstallCmd {
                 Utf8Path::from_path(&self.package_dir).unwrap(),
                 is_release_tarball,
                 self.rust_debug_target,
+                self.rust_target_triple.as_deref(),
             )?;
 
             let targets = package.targets(&dirs, &version, self.system)?;

--- a/src/project.rs
+++ b/src/project.rs
@@ -19,13 +19,14 @@ impl Project {
         projectdir: &Utf8Path,
         is_release_tarball: bool,
         rust_debug_target: bool,
+        rust_target_triple: Option<&str>,
     ) -> Result<Self> {
         Ok(Self {
             outputdir: if is_release_tarball {
                 None
             } else {
                 match project_type {
-                    Type::Rust => Some(get_target_dir_for_rust(projectdir, rust_debug_target)?),
+                    Type::Rust => Some(get_target_dir_for_rust(projectdir, rust_debug_target, rust_target_triple)?),
                     Type::Default | Type::Custom => None,
                 }
             },
@@ -37,6 +38,7 @@ impl Project {
 fn get_target_dir_for_rust(
     projectdir: &Utf8Path,
     rust_debug_target: bool,
+    rust_target_triple: Option<&str>,
 ) -> Result<Utf8PathBuf> {
     Ok(
         // if target directory does not exist, try reading the "target_directory"
@@ -75,6 +77,11 @@ fn get_target_dir_for_rust(
         } else {
             projectdir.join("target")
         }
+        .join(if let Some(triple) = rust_target_triple {
+            triple
+        } else {
+            ""
+        })
         .join(if rust_debug_target {
             "debug"
         } else {


### PR DESCRIPTION
Tested by installing `rinstall` itself, both with and without specifying a target triple.

Closes #2